### PR TITLE
Alternate storage sync implementation with deeper use of signals

### DIFF
--- a/examples/storage/src/main.rs
+++ b/examples/storage/src/main.rs
@@ -18,7 +18,7 @@ fn app(cx: Scope) -> Element {
         div {
             button {
                 onclick: move |_| {
-                    count_session.set(count_session.get() + 1);
+                    *count_session.write() += 1;
                 },
                 "Click me!"
             },

--- a/examples/storage/src/main.rs
+++ b/examples/storage/src/main.rs
@@ -27,7 +27,7 @@ fn app(cx: Scope) -> Element {
         div {
             button {
                 onclick: move |_| {
-                    count_local.set(count_local.get() + 1);
+                    *count_local.write() += 1;
                 },
                 "Click me!"
             },

--- a/src/storage/client_storage/web.rs
+++ b/src/storage/client_storage/web.rs
@@ -1,4 +1,4 @@
-use async_broadcast::broadcast;
+use async_broadcast::{broadcast, Receiver, InactiveReceiver, Sender};
 use dioxus::prelude::*;
 use serde::{de::DeserializeOwned, Serialize};
 use std::sync::OnceLock;
@@ -33,19 +33,17 @@ impl StorageSubscriber<LocalStorage> for LocalStorage {
     fn subscribe<T: DeserializeOwned + 'static>(
         _cx: &ScopeState,
         _key: &String,
-    ) -> Option<UseChannel<StorageChannelPayload<Self>>> {
-        let channel = CHANNEL.get_or_init(|| {
+    ) -> Option<Receiver<StorageChannelPayload<Self>>> {
+        let (_, rx) = CHANNEL.get_or_init(|| {
             let (tx, rx) = broadcast::<StorageChannelPayload<Self>>(5);
-            let channel = UseChannel::new(Uuid::new_v4(), tx, rx.deactivate());
-            let channel_clone = channel.clone();
-
+            let tx_clone = tx.clone();
             let closure = Closure::wrap(Box::new(move |e: web_sys::StorageEvent| {
                 log::info!("Storage event: {:?}", e);
                 let key: String = e.key().unwrap();
-                let channel_clone_clone = channel_clone.clone();
+                let tx_clone_clone  = tx_clone.clone();
                 wasm_bindgen_futures::spawn_local(async move {
-                    let result = channel_clone_clone
-                        .send(StorageChannelPayload::<Self> { key })
+                    let result = tx_clone_clone
+                        .broadcast(StorageChannelPayload::<Self> { key })
                         .await;
                     match result {
                         Ok(_) => log::info!("Sent storage event"),
@@ -58,9 +56,9 @@ impl StorageSubscriber<LocalStorage> for LocalStorage {
                 .add_event_listener_with_callback("storage", closure.as_ref().unchecked_ref())
                 .unwrap();
             closure.forget();
-            channel
+            (tx, rx.deactivate())
         });
-        Some(channel.clone())
+        Some(rx.activate_cloned())
     }
 
     fn unsubscribe(_key: &String) {
@@ -68,7 +66,7 @@ impl StorageSubscriber<LocalStorage> for LocalStorage {
     }
 }
 
-static CHANNEL: OnceLock<UseChannel<StorageChannelPayload<LocalStorage>>> = OnceLock::new();
+static CHANNEL: OnceLock<(Sender<StorageChannelPayload<LocalStorage>>, InactiveReceiver<StorageChannelPayload<LocalStorage>>)> = OnceLock::new();
 // End LocalStorage
 
 // Start SessionStorage

--- a/src/storage/persistence.rs
+++ b/src/storage/persistence.rs
@@ -3,7 +3,7 @@ use crate::storage::{
     SessionStorage,
 };
 use dioxus::prelude::*;
-use dioxus_signals::use_signal;
+use dioxus_signals::use_selector;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -56,6 +56,13 @@ pub fn use_persistent<T: Serialize + DeserializeOwned + Default + Clone + 'stati
             state
         }
     };
+    let state_clone = state.clone();
+    let state_signal = state.data;
+    use_selector(cx, move || {
+        log::info!("use_synced_storage_entry selector");
+        let _x = state_signal;
+        state_clone.save();
+    });
     state
 }
 

--- a/src/storage/persistence.rs
+++ b/src/storage/persistence.rs
@@ -2,8 +2,7 @@ use crate::storage::{
     storage_entry::{storage_entry, StorageEntry},
     SessionStorage,
 };
-use dioxus::prelude::*;
-use dioxus_signals::use_selector;
+use dioxus::prelude::{use_effect, ScopeState};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -11,7 +10,7 @@ use serde::Serialize;
 ///
 /// Depending on the platform this uses either local storage or a file storage
 #[allow(clippy::needless_return)]
-pub fn use_persistent<T: Serialize + DeserializeOwned + Default + Clone + 'static>(
+pub fn use_persistent<T: Serialize + DeserializeOwned + Default + Clone + PartialEq + 'static>(
     cx: &ScopeState,
     key: impl ToString,
     init: impl FnOnce() -> T,
@@ -58,9 +57,8 @@ pub fn use_persistent<T: Serialize + DeserializeOwned + Default + Clone + 'stati
     };
     let state_clone = state.clone();
     let state_signal = state.data;
-    use_selector(cx, move || {
-        log::info!("use_synced_storage_entry selector");
-        let _x = state_signal;
+    use_effect(cx, (&state_signal.value(),), move |_| async move {
+        log::info!("state value changed, trying to save");
         state_clone.save();
     });
     state

--- a/src/storage/storage_entry.rs
+++ b/src/storage/storage_entry.rs
@@ -204,7 +204,7 @@ where
     let state_clone = state.clone();
     use_selector(cx, move || {
         log::info!("use_synced_storage_entry selector");
-        let x = state_signal;
+        let _x = state_signal;
         state_clone.save();
     });
     &mut state.data

--- a/src/storage/storage_entry.rs
+++ b/src/storage/storage_entry.rs
@@ -1,4 +1,4 @@
-use dioxus::prelude::ScopeState;
+use dioxus::prelude::{ScopeState, use_effect};
 use dioxus_signals::{use_selector, use_signal, Signal};
 use postcard::to_allocvec;
 use serde::{de::DeserializeOwned, Serialize};
@@ -202,9 +202,8 @@ where
         });
     }
     let state_clone = state.clone();
-    use_selector(cx, move || {
+    use_effect(cx, (&state_signal,), move |_| async move {
         log::info!("use_synced_storage_entry selector");
-        let _x = state_signal;
         state_clone.save();
     });
     &mut state.data

--- a/src/storage/storage_entry.rs
+++ b/src/storage/storage_entry.rs
@@ -1,12 +1,10 @@
-use async_broadcast::Receiver;
-use dioxus::prelude::{ScopeState, to_owned, use_effect};
-use dioxus_signals::{use_signal, use_selector, Signal, Write};
+use dioxus::prelude::ScopeState;
+use dioxus_signals::{use_selector, use_signal, Signal};
 use postcard::to_allocvec;
 use serde::{de::DeserializeOwned, Serialize};
-use std::cell::Ref;
 use std::fmt::{Debug, Display};
-use std::ops::{Deref, DerefMut};
-use std::sync::{Mutex, Arc};
+use std::ops::Deref;
+use std::sync::{Arc, Mutex};
 
 use crate::utils::channel::{use_listen_channel, UseChannel};
 
@@ -59,7 +57,7 @@ pub trait StorageSubscriber<S: StorageBacking> {
     fn subscribe<T: DeserializeOwned + 'static>(
         cx: &ScopeState,
         key: &S::Key,
-    ) -> Option<Receiver<StorageChannelPayload<S>>>;
+    ) -> Option<UseChannel<StorageChannelPayload<S>>>;
     fn unsubscribe(key: &S::Key);
 }
 
@@ -80,7 +78,7 @@ impl<S: StorageBacking> Debug for StorageChannelPayload<S> {
 pub struct StorageEntry<S: StorageBacking, T: Serialize + DeserializeOwned + Clone + 'static> {
     pub(crate) key: S::Key,
     pub(crate) data: Signal<T>,
-    pub(crate) channel: Option<Receiver<StorageChannelPayload<S>>>,
+    pub(crate) channel: Option<UseChannel<StorageChannelPayload<S>>>,
     pub(crate) lock: Arc<Mutex<()>>,
 }
 
@@ -91,29 +89,14 @@ where
     S::Key: Clone,
 {
     fn new_synced(key: S::Key, data: T, cx: &ScopeState) -> Self {
-        let key_clone = key.clone();
         let channel = S::subscribe::<T>(cx, &key);
 
-        let retval = Self { key, data: Signal::new_in_scope(data, cx.scope_id()), channel, lock: Arc::new(Mutex::new(())) };
-        // let retval_clone = retval.clone();
-
-        if let Some(mut channel) = retval.channel.clone() {
-            cx.spawn(async move {
-                loop {
-                    let message = channel.recv().await;
-                    log::info!("message: {:?}", message);
-                    if let Ok(payload) = message {
-                        if key_clone == payload.key {
-                            *retval.data.write() = S::get(&key_clone).unwrap_or_else(|| {
-                                log::info!("get failed");
-                                retval.data.read().clone()
-                            });
-                        }
-                    }
-                }
-            });
+        Self {
+            key,
+            data: Signal::new_in_scope(data, cx.scope_id()),
+            channel,
+            lock: Arc::new(Mutex::new(())),
         }
-        retval
     }
 }
 
@@ -137,17 +120,6 @@ where
             S::set(self.key.clone(), &self.data);
         });
     }
-
-    // pub fn with_mut(&mut self, f: impl FnOnce(&mut T)) {
-    //     f(&mut self.data.write());
-    //     self.save()
-    // }
-
-    // pub fn write(&mut self) -> StorageEntryMut<'_, S, T> {
-    //     StorageEntryMut {
-    //         storage_entry: self,
-    //     }
-    // }
 
     pub fn update(&mut self) {
         self.data = S::get(&self.key).unwrap_or(self.data);
@@ -177,50 +149,6 @@ impl<S: StorageBacking, T: Debug + Serialize + DeserializeOwned + Clone> Debug
         self.data.fmt(f)
     }
 }
-
-// pub struct StorageEntryMut<'a, S, T>
-// where
-//     S: StorageBacking,
-//     T: Serialize + DeserializeOwned + Clone + 'static,
-//     S::Key: Clone,
-// {
-//     storage_entry: &'a StorageEntry<S, T>,
-// }
-
-// impl<'a, S, T> Deref for StorageEntryMut<'a, S, T>
-// where
-//     S: StorageBacking,
-//     T: Serialize + DeserializeOwned + Clone + 'static,
-//     S::Key: Clone,
-// {
-//     type Target = T;
-
-//     fn deref(&self) -> &Self::Target {
-//         &self.storage_entry.data.read()
-//     }
-// }
-
-// impl<'a, S, T> DerefMut for StorageEntryMut<'a, S, T>
-// where
-//     S: StorageBacking,
-//     T: Serialize + DeserializeOwned + Clone + 'static,
-//     S::Key: Clone,
-// {
-//     fn deref_mut(&mut self) -> &mut Self::Target {
-//         &mut self.storage_entry.data.write()
-//     }
-// }
-
-// impl<'a, S, T> Drop for StorageEntryMut<'a, S, T>
-// where
-//     S: StorageBacking,
-//     T: Serialize + DeserializeOwned + Clone + 'static,
-//     S::Key: Clone,
-// {
-//     fn drop(&mut self) {
-//         self.storage_entry.save();
-//     }
-// }
 
 pub fn storage_entry<S: StorageBacking, T: Serialize + DeserializeOwned>(
     key: S::Key,
@@ -260,100 +188,24 @@ where
     T: Serialize + DeserializeOwned + Clone + 'static,
     S::Key: Clone,
 {
-    let cx_clone = cx.clone();
-    let state = cx.use_hook(|| synced_storage_entry::<S, T>(key, init, cx_clone));
-    let state_clone = state.clone();
+    let key_signal = use_signal(cx, || key.clone());
+    let state = cx.use_hook(|| synced_storage_entry::<S, T>(key, init, cx));
     let state_signal = state.data;
-    use_selector(cx_clone, move || {
+    if let Some(channel) = state.channel.clone() {
+        use_listen_channel(cx, &channel, move |message| async move {
+            if let Ok(payload) = message {
+                *state_signal.write() = S::get(&key_signal.read()).unwrap_or_else(|| {
+                    log::info!("get failed");
+                    state_signal.read().clone()
+                });
+            }
+        });
+    }
+    let state_clone = state.clone();
+    use_selector(cx, move || {
         log::info!("use_synced_storage_entry selector");
         let x = state_signal;
         state_clone.save();
     });
     &mut state.data
 }
-
-// //  Start UseStorageEntry
-// /// Storage that persists across application reloads
-// #[derive(Clone, Copy)]
-// pub struct UseStorageEntry<S: StorageBacking, T: Serialize + DeserializeOwned + Clone + 'static> {
-//     inner: Signal<StorageEntry<S, T>>,
-// }
-
-// #[allow(unused)]
-// impl<S: StorageBacking, T: Serialize + DeserializeOwned + Clone + 'static> UseStorageEntry<S, T> {
-//     pub fn new(signal: Signal<StorageEntry<S, T>>) -> Self {
-//         Self { inner: signal }
-//     }
-
-//     /// Returns a reference to the value
-//     pub fn read(&self) -> Ref<T> {
-//         Ref::map(self.inner.read(), |entry| &entry.data)
-//     }
-
-//     pub fn write(&self) -> Write<'_, T, StorageEntry<S,T>> {
-//         Write::map(self.inner.write(), |entry| &mut entry.data)
-//     }
-
-//     /// Sets the value
-//     pub fn set(&self, value: T) {
-//         self.inner.write().with_mut(|data| *data = value)
-//     }
-
-//     /// Modifies the value
-//     pub fn modify<F: FnOnce(&mut T)>(&self, f: F) {
-//         let writer = &mut *self.inner.write();
-//         writer.with_mut(f);
-//     }
-// }
-
-// #[allow(unused)]
-// impl<S: StorageBacking, T: Serialize + DeserializeOwned + Default + Clone + 'static>
-//     UseStorageEntry<S, T>
-// {
-//     /// Returns a clone of the value
-//     pub fn get(&self) -> T {
-//         self.read().clone()
-//     }
-// }
-
-// impl<S: StorageBacking, T: Serialize + DeserializeOwned + Default + Display + Clone + 'static>
-//     Display for UseStorageEntry<S, T>
-// {
-//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-//         (*self.read()).fmt(f)
-//     }
-// }
-
-// impl<S: StorageBacking, T: Serialize + DeserializeOwned + Default + Clone + 'static> Deref
-//     for UseStorageEntry<S, T>
-// {
-//     type Target = Signal<StorageEntry<S, T>>;
-
-//     fn deref(&self) -> &Self::Target {
-//         &self.inner
-//     }
-// }
-
-// impl<S: StorageBacking, T: Serialize + DeserializeOwned + Default + Clone + 'static> DerefMut
-//     for UseStorageEntry<S, T>
-// {
-//     fn deref_mut(&mut self) -> &mut Self::Target {
-//         &mut self.inner
-//     }
-// }
-
-// End UseStorageEntry
-
-// state.with(move |state| {
-//     if let Some(channel) = &state.channel {
-
-//         use_listen_channel(cx, channel, move |message: Result<StorageChannelPayload<S>, async_broadcast::RecvError>| async move {
-//             if let Ok(payload) = message {
-//                 if state.key == payload.key {
-//                     state.update();
-//                 }
-//             }
-//         });
-//     }
-// });
-// state

--- a/src/storage/storage_entry.rs
+++ b/src/storage/storage_entry.rs
@@ -185,7 +185,7 @@ pub fn use_synced_storage_entry<S, T>(
 ) -> &mut Signal<T>
 where
     S: StorageBacking + StorageSubscriber<S>,
-    T: Serialize + DeserializeOwned + Clone + 'static,
+    T: Serialize + DeserializeOwned + Clone + PartialEq + 'static,
     S::Key: Clone,
 {
     let key_signal = use_signal(cx, || key.clone());
@@ -202,8 +202,8 @@ where
         });
     }
     let state_clone = state.clone();
-    use_effect(cx, (&state_signal,), move |_| async move {
-        log::info!("use_synced_storage_entry selector");
+    use_effect(cx, (&state_signal.value(),), move |_| async move {
+        log::info!("state value changed, trying to save");
         state_clone.save();
     });
     &mut state.data


### PR DESCRIPTION
This is a bit of a hacky setup but it shows off another approach to synchronizing data where the StorageEntry actually uses the signal under the hood and the work of updating the storage medium on change is handled by a selector. This is not optimal right now, as each time an instance gets updated from a storage event, it will then write again to set the data back in the storage. 